### PR TITLE
Use a custom (manual) build of jmx_exporter (IDR-0.4.2)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,15 +14,15 @@
 - name: prometheus jmx | download jar
   become: yes
   get_url:
-    url: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.8/jmx_prometheus_javaagent-0.8.jar
-    checksum: "sha256:c32440e4a98b441b4ab66a788df77494d32e1560e0f3bb5342752bf064408520"
-    dest: /opt/prometheus/jars/jmx_prometheus_javaagent-0.8.jar
+    url: http://users.openmicroscopy.org.uk/~spli/idr/jmx_exporter/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
+    checksum: "sha256:48e2a9a5fc8e9f272981e5ec23f433e08a5abc4141ef568d2db6af34618a4265"
+    dest: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
     force: no
 
 - name: prometheus jmx | symlink jar
   become: yes
   file:
-    src: /opt/prometheus/jars/jmx_prometheus_javaagent-0.8.jar
+    src: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
     path: /opt/prometheus/jars/jmx_prometheus_javaagent.jar
     force: yes
     state: link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,15 +14,15 @@
 - name: prometheus jmx | download jar
   become: yes
   get_url:
-    url: http://users.openmicroscopy.org.uk/~spli/idr/jmx_exporter/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
-    checksum: "sha256:48e2a9a5fc8e9f272981e5ec23f433e08a5abc4141ef568d2db6af34618a4265"
-    dest: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
+    url: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.10/jmx_prometheus_javaagent-0.10.jar
+    checksum: "sha256:b144a5a22fc9ee62d8d198f0dcc622f851c77cf52fee4bd529afbc266af37e29"
+    dest: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10.jar
     force: no
 
 - name: prometheus jmx | symlink jar
   become: yes
   file:
-    src: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar
+    src: /opt/prometheus/jars/jmx_prometheus_javaagent-0.10.jar
     path: /opt/prometheus/jars/jmx_prometheus_javaagent.jar
     force: yes
     state: link


### PR DESCRIPTION
This installs a custom (manual) build of jmx_exporter to test whether https://github.com/prometheus/jmx_exporter/issues/156 is fixed by https://github.com/prometheus/jmx_exporter/pull/162

# Details:

Repository: https://github.com/prometheus/jmx_exporter
Commit:
```
commit 5b180affbefa445088d4608b9640ca404ce91ae2
Author: Leo Gomes <leonardo.f.gomes@gmail.com>
Date:   Mon Jul 17 14:34:30 2017 +0200

    Use simple HTTP Server (#162)
```
Build: `docker run -it --rm -v $PWD:/build -w /build maven mvn package`
Artifact: `jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-0.10-SNAPSHOT.jar`